### PR TITLE
Fixes precompile problem

### DIFF
--- a/lib/jPicker-rails/version.rb
+++ b/lib/jPicker-rails/version.rb
@@ -1,5 +1,5 @@
 module JPicker
   module Rails
-    VERSION = "0.3"
+    VERSION = "0.4"
   end
 end

--- a/vendor/assets/javascripts/jpicker/jpicker-pipeline.js.erb
+++ b/vendor/assets/javascripts/jpicker/jpicker-pipeline.js.erb
@@ -1,2 +1,2 @@
 /* inject asset path to image location */
-$.fn.jPicker.defaults.images.clientPath='<%= asset_path('jpicker/') %>';
+$.fn.jPicker.defaults.images.clientPath='<%= asset_path('assets/jpicker/*').tr('*', '') %>';


### PR DESCRIPTION
This fix prevents the following error on precompile:

```
ActionView::Template::Error (Asset logical path has no extension: jpicker/.js
  (in ~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/jpicker-rails-0.1/app/assets/javascripts/jpicker/jpicker-pipeline.js.erb)):
```
